### PR TITLE
fix slider position change

### DIFF
--- a/src/StepRangeSlider.js
+++ b/src/StepRangeSlider.js
@@ -37,7 +37,8 @@ export default class StepRangeSlider extends Component {
       nextProps.value !== this.state.value
     ) {
       const value = this.state.range.ensureValue(nextProps.value)
-      this.setState({ value })
+      const currentStep = this.state.range.getStepForValue(value)
+      this.setState({ value,currentStep })
     }
   }
 


### PR DESCRIPTION
If I change StepRangeSlider value programmatically the slider position won't change. Though I could see a new value in the child tooltip. Looks like my commit will fix the problem. 